### PR TITLE
expand extended description for `match:regexp` - and add moreInfoUrl

### DIFF
--- a/machines/match.js
+++ b/machines/match.js
@@ -30,6 +30,7 @@ module.exports = {
         'The regular expression should be specified as a string WITHOUT including leading or trailing slashes '+
         'or modifiers like `/gi`.  For example, don\'t type `/f[o]+/i`.  Instead, type `f[o]+` and also set '+
         '"Case insensitive?" to true.',
+      moreInfoUrl: 'https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp',
       required: true
     },
 

--- a/machines/match.js
+++ b/machines/match.js
@@ -26,7 +26,10 @@ module.exports = {
       friendlyName: 'Regular expression',
       example: 'w(\\w+)d',
       description: 'The regular expression to match against (i.e. "metal detector").',
-      extendedDescription: 'The regular expression should be specified as a string WITHOUT including leading or trailing slashes or modifiers like /gi.',
+      extendedDescription:
+        'The regular expression should be specified as a string WITHOUT including leading or trailing slashes '+
+        'or modifiers like `/gi`.  For example, don\'t type `/f[o]+/i`.  Instead, type `f[o]+` and also set '+
+        '"Case insensitive?" to true.',
       required: true
     },
 


### PR DESCRIPTION
Note that this should probably also be brought over for the "Is valid regexp?" machine.
