### PR TITLE
Use `encodeURIComponent` instead of `encoreURI` for `url-friendly` style

### DIFF
--- a/lib/random.js
+++ b/lib/random.js
@@ -64,17 +64,19 @@ module.exports = {
 
       token = buf.toString('base64');
 
-      // Encode URI just to be safe / clear (this leaves most special chars intact)
-      // > https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI
-      token = encodeURIComponent(token);
-
       // Get rid of plus signs (+) to avoid weird issues with spaces
-      // in some parsing libraries (e.g. Sails/Express/Koa)
+      // in some parsing libraries (e.g. Sails/Express/Koa),
+      // as well as / (to make it valid in a URI path component),
+      // and = (to hide that it's base64-encoded, and for aesthetics).
       //
       // > Note also that "+" is technically legal:
       // > https://stackoverflow.com/a/31300627/486547
       // > ...we just change it anyway to avoid issues.
-      token = token.replace(/\+/g, '');
+      token = token.replace(/[+/=]/g, '');
+
+      // Note -- we used to also do `encodeURI` here, but since the
+      // only special chars in a Base-64-encoded string are /, = and +,
+      // and we removed all those above, encoding is no longer necessary.
 
     }else if (inputs.style === 'alphanumeric') {
 

--- a/lib/random.js
+++ b/lib/random.js
@@ -66,7 +66,7 @@ module.exports = {
 
       // Encode URI just to be safe / clear (this leaves most special chars intact)
       // > https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURI
-      token = encodeURI(token);
+      token = encodeURIComponent(token);
 
       // Get rid of plus signs (+) to avoid weird issues with spaces
       // in some parsing libraries (e.g. Sails/Express/Koa)


### PR DESCRIPTION
`encodeURI` is good for encoding _entire_ URLs, since it doesn't encode forward slashes.  But base-64 encoded strings may have slashes, which makes them unsuitable for use in a URL path like /notification/:token/read